### PR TITLE
added ability to compare new benchmarks to old profiles still using deprecated IDs (V-XXXXXX)

### DIFF
--- a/lib/inspec_delta/commands/profile.rb
+++ b/lib/inspec_delta/commands/profile.rb
@@ -18,9 +18,25 @@ module InspecDelta
                     desc: 'Sets inspec_delta to use STIG Rule IDs (SV-XXXXXX) as the primary key for comparison between the benchmark and the profile. Set to false to use the Vuln ID (V-XXXXXX) as the comparator.',
                     type: :boolean,
                     default: true
+
       def update
         prof = InspecDelta::Object::Profile.new(options[:profile_path])
         prof.update(options[:stig_file_path], options[:rule_id])
+        prof.format
+      end
+
+      desc 'update_id', 'Relabel the controls in the profile with the updated IDs from the benchmark. Run this first if the profile uses the old-stlye V-XXXXXX IDs and you want to rename the files with the right IDs in a separate commit.'
+      method_option :profile_path,
+                    aliases: %w[-p --pr],
+                    desc: 'The path to the directory that contains the profile to modify.',
+                    required: true
+      method_option :stig_file_path,
+                    aliases: %w[-s --st],
+                    desc: 'The path to the stig file to apply to the profile.',
+                    required: true
+      def update_id
+        prof = InspecDelta::Object::Profile.new(options[:profile_path])
+        prof.update_id(options[:stig_file_path])
         prof.format
       end
     end

--- a/lib/inspec_delta/commands/profile.rb
+++ b/lib/inspec_delta/commands/profile.rb
@@ -13,9 +13,14 @@ module InspecDelta
                     aliases: %w[-s --st],
                     desc: 'The path to the stig file to apply to the profile.',
                     required: true
+      method_option :rule_id,
+                    aliases: '-r',
+                    desc: 'Sets inspec_delta to use STIG Rule IDs (SV-XXXXXX) as the primary key for comparison between the benchmark and the profile. Set to false to use the Vuln ID (V-XXXXXX) as the comparator.',
+                    type: :boolean,
+                    default: true
       def update
         prof = InspecDelta::Object::Profile.new(options[:profile_path])
-        prof.update(options[:stig_file_path])
+        prof.update(options[:stig_file_path], options[:rule_id])
         prof.format
       end
     end

--- a/lib/inspec_delta/objects/profile.rb
+++ b/lib/inspec_delta/objects/profile.rb
@@ -48,6 +48,34 @@ module InspecDelta
         end
       end
 
+      # Updates ONLY the filenames of the profile's controls metadata with definitions from a STIG xml file
+      #
+      # @param [profile_path] String - path to the inspec profile's root directory.
+      # @param [stig_file_path] String - The STIG file to be applied to profile.
+      def update_id(stig_file_path)
+        raise StandardError, "STIG file at #{stig_file_path} not found" unless File.exist?(stig_file_path)
+          control_dir = "#{@profile_path}/controls"
+          benchmark = InspecDelta::Parser::Benchmark.get_benchmark(stig_file_path)
+          benchmark.each do |control_id, control| unless control[:legacy].nil? || control[:legacy].empty?
+            benchmark_control = InspecDelta::Object::Control.from_benchmark(control)
+            control_filename = "#{control[:legacy].select{ |x| x.start_with? ('V-') }.first}.rb"
+            profile_control_path = File.join(File.expand_path(control_dir), control_filename)
+            #require 'pry'; binding.pry
+            if File.file?(profile_control_path)
+              puts "Updating \"#{control_filename}\" ==> \"#{control[:id]}.rb\""
+              updated_path = profile_control_path.sub(
+                /[^\/\\]+.rb/,
+                control[:id] + '.rb'
+              )
+              system("cd #{@profile_path} && git mv #{profile_control_path} #{updated_path}")
+              #require 'pry'; binding.pry
+            end
+          end
+          puts "Done updating."
+        end
+      end
+
+
       # Updates a control file with the updates from the stig
       #
       # @param [profile_control_path] String - The location of the Inspec profile on disk
@@ -59,11 +87,12 @@ module InspecDelta
           /[^\/\\]+.rb/,
           updated_control[:id] + '.rb'
         )
-        
-        File.open(profile_control_path, 'w') { |f| f.puts updated_control[:control_string] }
         if updated_path != profile_control_path
-          File.rename(profile_control_path, updated_path)
+          #require 'pry'; binding.pry
+          system("cd #{@profile_path} && git mv #{profile_control_path} #{updated_path}")
+          profile_control_path = updated_path
         end
+        File.open(profile_control_path, 'w') { |f| f.puts updated_control[:control_string] }
       end
 
       # Creates a control file with the string representation of the benchmark control

--- a/lib/inspec_delta/objects/profile.rb
+++ b/lib/inspec_delta/objects/profile.rb
@@ -71,8 +71,8 @@ module InspecDelta
               #require 'pry'; binding.pry
             end
           end
-          puts "Done updating."
         end
+        puts "Done updating."
       end
 
 

--- a/lib/inspec_delta/parsers/benchmark.rb
+++ b/lib/inspec_delta/parsers/benchmark.rb
@@ -24,12 +24,12 @@ module InspecDelta
 
           g[:stig_title] = benchmark_title
 
-          g[:id] = b.id
           g[:gtitle] = b.title
           g[:description] = b.description
           g[:gid] = b.id
 
           rule = b.rule
+          g[:id] = rule.id.scan(/SV-[\d]+/).first
           g[:rid] = rule.id
           g[:severity] = rule.severity
           g[:stig_id] = rule.version
@@ -62,6 +62,7 @@ module InspecDelta
           g[:dc_type] = reference_group.dc_type
 
           g[:cci] = rule.idents.select { |t| t.start_with?('CCI-') } # XCCDFReader
+          g[:legacy] = rule.idents.select { |t| !t.start_with?('CCI-') }
 
           g[:fix] = rule.fixtext
           g[:fix_id] = rule.fix.id
@@ -69,7 +70,7 @@ module InspecDelta
           g[:check] = rule.check.content
           g[:check_ref_name] = rule.check.content_ref.name
           g[:check_ref] = rule.check.content_ref.href
-          [b.id, g]
+          [g[:id], g]
         end
         mapped_benchmark_group.to_h
       end


### PR DESCRIPTION
resolves #18, #16

Use `--rule-id false` to have inspec_delta look up profile controls using the legacy vulnerability ID field (V-XXXXXX) in the updated benchmark. 

- The flag defaults to true since this should only be necessary for older profiles.
- inspec_delta will rename the control (`control SV-IMANEWNUMBER`) and the control file (`SV-NEWNUMBER.rb`) to use the new Rule ID.
- inspec_delta also populates a legacy ID tag now

```
inspec_delta profile update -p profileOldIDs -s benchmarkNewIDs --rule-id false
```

Signed-off-by: Will Dower <wdower@mitre.org>